### PR TITLE
Update for Haxe 3.1.3 compatibility

### DIFF
--- a/src/haxe/io/Bytes.hx
+++ b/src/haxe/io/Bytes.hx
@@ -158,7 +158,7 @@ class Bytes {
 		#end
 	}
 
-	public function readString( pos : Int, len : Int ) : String {
+	public function getString( pos : Int, len : Int ) : String {
 		#if !neko
 		if( pos < 0 || len < 0 || pos + len > length ) throw Error.OutsideBounds;
 		#end
@@ -204,6 +204,12 @@ class Bytes {
 		#end
 	}
 
+	@:deprecated("readString is deprecated, use getString instead")
+	@:noCompletion
+	public inline function readString(pos:Int, len:Int):String {
+		return getString(pos, len);
+	}
+
 	public function toString() : String {
 		#if neko
 		return new String(untyped __dollar__ssub(b,0,length));
@@ -215,7 +221,7 @@ class Bytes {
 		return cast b;
 //		return untyped __call__("call_user_func_array", "pack", __call__("array_merge", __call__("array", "C*"), b.»a));
 		#else
-		return readString(0,length);
+		return getString(0,length);
 		#end
 	}
 	

--- a/src/haxe/io/BytesBuffer.hx
+++ b/src/haxe/io/BytesBuffer.hx
@@ -39,6 +39,9 @@ class BytesBuffer {
 	var b : Array<Int>;
 	#end
 
+	/** The length of the buffer in bytes. **/
+	public var length(get,never) : Int;
+
 	public function new() {
 		#if neko
 		b = untyped StringBuf.__make();
@@ -54,6 +57,18 @@ class BytesBuffer {
 		b = new java.io.ByteArrayOutputStream();
 		#else
 		b = new Array();
+		#end
+	}
+
+	inline function get_length() : Int {
+		#if neko
+		return untyped __dollar__ssize( StringBuf.__to_string(b) );
+		#elseif cs
+		return haxe.Int64.toInt( b.Length );
+		#elseif java
+		return b.size();
+		#else
+		return b.length;
 		#end
 	}
 


### PR DESCRIPTION
Reflecting changes to Bytes and BytesBuffer in the standard library, see http://haxe.org/download/version/3.1.3/ for release notes.
