### PR TITLE
Removed js.Node.Error which exists in std lib as js.Error.

### DIFF
--- a/src/js/Node.hx
+++ b/src/js/Node.hx
@@ -851,12 +851,6 @@ typedef NodeJson = {
 	function parse(text :String) :Dynamic;
 }
 
-@:native("Error")
-extern class Error
-{
-	public function new(msg : String) : Void;
-}
-
 // Node Constants
 class NodeC {
 	public static inline var UTF8 = "utf8";


### PR DESCRIPTION
The `js.Error` in std lib is more complete.
`js.Node.Error` also lives in the `js` package so it will shadow `js.Error` in std lib.
