### PR TITLE
Use getter in newSocket properly

### DIFF
--- a/src/js/Node.hx
+++ b/src/js/Node.hx
@@ -972,7 +972,8 @@ class Node {
 	static inline function get_json() : NodeJson return untyped __js__('JSON');
 
 	public static function newSocket(?options):NodeNetSocket {
-		return untyped __js__("new js.Node.net.Socket(options)");
+		var net = js.Node.net;
+		return untyped __js__("new net.Socket(options)");
 	}
 }
 


### PR DESCRIPTION
After compilation there's no `js.Node.net`, only `js.Node.get_net`