### PR TITLE
Add missing Sys class methods needed to run lime-based apps

### DIFF
--- a/Sys.hx
+++ b/Sys.hx
@@ -11,22 +11,22 @@ class Sys
 {
 	public static function args () :Array<String>
 	{
-		return Node.process.argv;
+		return untyped process.argv;
 	}
 
 	public static function getEnv (key :String) :String
 	{
-		return Reflect.field(Node.process.env, key);
+		return Reflect.field(untyped process.env, key);
 	}
 
 	public static function environment () : haxe.ds.StringMap<String>
 	{
-		return Node.process.env;
+		return untyped process.env;
 	}
 
 	public static function exit (code :Int) :Void
 	{
-		Node.process.exit(code);
+		untyped process.exit(code);
 	}
 
 	/**

--- a/Sys.hx
+++ b/Sys.hx
@@ -36,4 +36,28 @@ class Sys
 	{
 		return untyped __js__('Date.now() / 1000');
 	}
+	
+	public static function systemName() : String {
+		switch(untyped process.platform)
+		{
+		case "darwin": return "Darwin";
+		case "freebsd": return "BSD";
+		case "linux": return "Linux";
+		case "sunos": return "SunOS";
+		case "win32": return "Windows";
+		default: return "";
+		}
+	}
+	
+	public static function println(v:Dynamic) : Void {
+		untyped console.log(v);
+	}
+	
+	public static function executablePath() : String {
+		return untyped process.execPath;
+	}
+	
+	public static function setCwd(s:String) : Void {
+		untyped process.chdir(s);
+	}
 }


### PR DESCRIPTION
And in second commit, I changed the code to access Node's built-in variables directly, because static variables of Haxe might be used before they are initialized.